### PR TITLE
Update to 1.21.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,10 +39,10 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-    modImplementation include("eu.pb4:polymer-core:0.13.11+1.21.8")
-    modImplementation include("xyz.nucleoid:server-translations-api:2.5.1+1.21.5")
-    modImplementation include("eu.pb4:polymer-virtual-entity:0.13.11+1.21.8")
-    modImplementation "maven.modrinth:lootr:5T0cn166"
+    modImplementation include("eu.pb4:polymer-core:0.14.2+1.21.9")
+    modImplementation include("xyz.nucleoid:server-translations-api:2.5.2+1.21.9-pre3")
+    modImplementation include("eu.pb4:polymer-virtual-entity:0.14.2+1.21.9")
+    modImplementation "maven.modrinth:lootr:T2K9YC05"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,17 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
+
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.8
-yarn_mappings=1.21.8+build.1
+minecraft_version=1.21.9
+yarn_mappings=1.21.9+build.1
 loader_version=0.17.2
+loom_version=1.11-SNAPSHOT
+
 # Mod Properties
 mod_version=1.0-SNAPSHOT
 maven_group=tornato
 archives_base_name=LootrPolymer
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.132.0+1.21.8
+fabric_version=0.134.0+1.21.9

--- a/src/main/resources/data/lootr/lang/en_us.json
+++ b/src/main/resources/data/lootr/lang/en_us.json
@@ -14,5 +14,10 @@
     "lootr.message.refreshed": "The contents of the container are refreshed at your touch!",
     "lootr.message.should_sneak": "Breaking the chest will delete your unique loot and all items in the chest! In order to break, you must sneak while doing so.",
     "lootr.message.should_sneak2": "As loot is %s, only break if really needed.",
-    "lootr.message.should_sneak3": "per-player per-chest"
+    "lootr.message.should_sneak3": "per-player per-chest",
+    "tag.item.lootr.barrels": "Lootr Barrels",
+    "tag.item.lootr.chests": "Lootr Chests",
+    "tag.item.lootr.containers": "Lootr Containers",
+    "tag.item.lootr.shulkers": "Lootr Shulkers",
+    "tag.item.lootr.trapped_chests": "Trapped Lootr Chests"
 }


### PR DESCRIPTION
- Update to 1.21.9
- Fixed missing translations

I also discovered that the blocking of lootr advancements is not working, but I couldn't find a way to fix it.
